### PR TITLE
chore: Java 17に対応

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/openjdk:11-jdk
+      - image: cimg/openjdk:17.0.9
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:17-jre
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {
@@ -42,7 +42,9 @@ application {
 }
 
 jar {
-    manifest {
-        attributes 'Main-Class': 'com.sakamotodesu.bittrader.App'
-    }
+    enabled = false
+}
+
+bootJar {
+    archiveClassifier = ''
 }


### PR DESCRIPTION
# Java 17に対応

## 変更内容
- `build.gradle`のJavaバージョンを17に更新
  - `sourceCompatibility`を`JavaVersion.VERSION_17`に変更
  - `targetCompatibility`を`JavaVersion.VERSION_17`に変更
  - `jar`タスクの設定を更新し、Spring Bootの依存関係を正しく含めるように修正
- `Dockerfile`のベースイメージを`eclipse-temurin:17-jre`に更新

## 変更理由
- Spring Boot 3.xへの移行準備として、Java 17への対応を先行して実施
- 最新のJavaバージョンを使用することで、セキュリティと機能の改善を確保

## 動作確認
- [x] Gradleビルドが成功
- [x] Dockerイメージのビルドが成功
- [x] アプリケーションの起動が成功
- [x] Spring Bootアプリケーションが正常に動作 