### PR TITLE
chore: Spring Boot 3.2.3に更新

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,19 +10,21 @@ plugins {
     id 'java'
     id 'application'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'org.springframework.boot' version '2.7.18'
-    id "io.spring.dependency-management" version "1.1.7"
+    id 'org.springframework.boot' version '3.2.3'
+    id "io.spring.dependency-management" version "1.1.4"
     id 'war'
 }
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
@@ -33,7 +35,7 @@ dependencies {
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 
     // Use JUnit test framework
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 application {

--- a/src/main/java/com/sakamotodesu/bittrader/App.java
+++ b/src/main/java/com/sakamotodesu/bittrader/App.java
@@ -1,19 +1,19 @@
 package com.sakamotodesu.bittrader;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@EnableAutoConfiguration
+@SpringBootApplication
 public class App {
 
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);
     }
 
-    @RequestMapping("/")
+    @GetMapping("/")
     String home() {
         BitflyerApi bitflyerApi = new BitflyerApi();
         return bitflyerApi.request();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+# サーバー設定
+server.port=8080
+
+# ログ設定
+logging.level.root=INFO
+logging.level.com.sakamotodesu.bittrader=DEBUG
+
+# Spring Boot設定
+spring.main.banner-mode=off 

--- a/src/test/java/com/sakamotodesu/bittrader/AppTest.java
+++ b/src/test/java/com/sakamotodesu/bittrader/AppTest.java
@@ -3,12 +3,13 @@
  */
 package com.sakamotodesu.bittrader;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AppTest {
-    @Test public void testAppHasAGreeting() {
+    @Test
+    void testAppHasAGreeting() {
         App classUnderTest = new App();
-        assertNotNull("app should have a greeting", classUnderTest.getGreeting());
+        assertNotNull(classUnderTest.getGreeting(), "app should have a greeting");
     }
 }


### PR DESCRIPTION
# Spring Boot 3.2.3に更新

Spring Bootを3.2.3に更新し、Java 17に対応しました。

## 変更内容

### 依存関係の更新
- Spring Bootを3.2.3に更新
- Spring Dependency Managementを1.1.4に更新
- JUnit 4からSpring Boot Testに移行

### Java 17対応
- Java 17のツールチェーンを設定
- ソースコードとターゲットをJava 17に設定

### アプリケーション設定
- `application.properties`を追加
  - サーバーポートを8080に設定
  - ログレベルを設定
  - Spring Bootのバナー表示を無効化

### コード変更
- `@EnableAutoConfiguration`を`@SpringBootApplication`に変更
- `@RequestMapping`を`@GetMapping`に変更
- テストコードをJUnit 5に移行

## 動作確認
- [x] Gradleビルドが成功
- [x] テストが成功
- [x] アプリケーションが起動
- [x] APIエンドポイントが正常に動作 