### PR TITLE
Update Gradle to latest version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun May 03 16:43:04 JST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade Gradle from 8.6 to 9.2.0 (latest stable version as of 2025-11) This brings improvements in:
- Task execution efficiency with improved work graph building
- Windows ARM64 support
- Stable Daemon toolchain (no longer incubating)