### PR TITLE
fix: Gradle 9でのCIビルドエラーを修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@
 plugins {
     id 'java'
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'org.springframework.boot' version '4.1.0'
     id "io.spring.dependency-management" version "1.1.7"
     id 'war'
@@ -40,7 +39,11 @@ dependencies {
 
 application {
     // Define the main class for the application.
-    mainClassName = 'com.sakamotodesu.bittrader.App'
+    mainClass = 'com.sakamotodesu.bittrader.App'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
 }
 
 jar {


### PR DESCRIPTION
## 概要

DependabotによるGradle 9系への更新後に失敗していたCIビルドを修正します。

## 変更内容

- Gradle 9と互換性がなく、プロジェクト内で使用されていないShadow plugin 8.1.1を削除
- 廃止された`application.mainClassName`を`application.mainClass`へ移行
- JUnit 5テストを検出するため`useJUnitPlatform()`を明示

## 原因

Shadow plugin 8.1.1がGradle 9で削除された`fileMode`プロパティを設定しようとし、プラグイン適用時にビルドが停止していました。その問題を除去した後、残っていたGradle 9非互換設定とJUnit Platform未設定も顕在化したため、あわせて修正しています。

## 影響

Spring Bootの`bootJar`生成は維持されます。未使用だったShadow pluginによるfat JAR生成機能のみ削除されます。

## 確認

- `./gradlew test bootJar`
- `git diff --check`
